### PR TITLE
Add submit-transaction api

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -51,4 +51,5 @@
 - `POST send-bitclout`
 - `POST send-message-stateless`
 - `POST submit-post`
+- `POST submit-transaction`
 - `POST update-user-global-metadata`


### PR DESCRIPTION
POST submit-transaction is used to verify a post. Without this the post will never be verified and no-one can see it.

bitclout -> @suketudp